### PR TITLE
Add support to Akida 1500

### DIFF
--- a/99-akida-pcie.rules
+++ b/99-akida-pcie.rules
@@ -4,3 +4,4 @@
 # Akida PCIe interface
 
 KERNEL=="akida[0-9]*", MODE="0666"
+KERNEL=="akd1500_[0-9]*", MODE="0666"

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ ifneq ($(KERNELRELEASE),)
 # copied in kernel/x.y/ subdirectory depending on kernel API changes.
 # These files are drivers/dma/dmaengine.h and drivers/dma/virt-dma.h
 AKIDA_KERNEL_VERSION_RANK := $(shell \
-	printf "$(VERSION).$(PATCHLEVEL)\n4.9\n4.14\n4.16\n5.2\n5.3\n5.4\n5.6\n5.7\n5.16\n5.18\n" | \
+	printf "$(VERSION).$(PATCHLEVEL)\n4.9\n4.14\n4.16\n5.2\n5.3\n5.4\n5.6\n5.7\n5.16\n6.0\n" | \
 	sort -V )
 
 ifneq ($(word 1,$(AKIDA_KERNEL_VERSION_RANK)), 4.9)
@@ -30,7 +30,7 @@ else ifneq ($(word 8,$(AKIDA_KERNEL_VERSION_RANK)), 5.7)
 ccflags-y += -I$(src)/kernel/5.6/drivers/dma
 else ifneq ($(word 9,$(AKIDA_KERNEL_VERSION_RANK)), 5.16)
 ccflags-y += -I$(src)/kernel/5.7/drivers/dma
-else ifneq ($(word 10,$(AKIDA_KERNEL_VERSION_RANK)), 5.18)
+else ifneq ($(word 10,$(AKIDA_KERNEL_VERSION_RANK)), 6.0)
 ccflags-y += -I$(src)/kernel/5.16/drivers/dma
 else
 $(error Kernel $(VERSION).$(PATCHLEVEL) not supported. Some incompatibilities can be present)

--- a/akida-dw-edma/dw-edma-core.c
+++ b/akida-dw-edma/dw-edma-core.c
@@ -424,7 +424,7 @@ dw_edma_device_transfer(struct dw_edma_transfer *xfer)
 		chunk->ll_region.sz += burst->sz;
 		desc->alloc_sz += burst->sz;
 
-		if (chan->dir == EDMA_DIR_WRITE) {
+		if (dir == DMA_DEV_TO_MEM) {
 			burst->sar = src_addr;
 			if (xfer->type == EDMA_XFER_CYCLIC) {
 				burst->dar = xfer->xfer.cyclic.paddr;

--- a/akida-dw-edma/dw-edma-v0-core.c
+++ b/akida-dw-edma/dw-edma-v0-core.c
@@ -421,17 +421,18 @@ void dw_edma_v0_core_start(struct dw_edma_chunk *chunk, bool first)
 		SET_CH_32(dw, chan->dir, chan->id, ch_control1,
 			  (DW_EDMA_V0_CCS | DW_EDMA_V0_LLE));
 		/* Linked list */
+
 		#ifdef CONFIG_64BIT
-			/* llp is not aligned on 64bit -> keep 32bit accesses */
-			SET_CH_32(dw, chan->dir, chan->id, llp.lsb,
-				  lower_32_bits(chunk->ll_region.paddr));
-			SET_CH_32(dw, chan->dir, chan->id, llp.msb,
-				  upper_32_bits(chunk->ll_region.paddr));
+		/* llp is not aligned on 64bit -> keep 32bit accesses */
+		SET_CH_32(dw, chan->dir, chan->id, llp.lsb,
+			  lower_32_bits(chunk->ll_region.paddr));
+		SET_CH_32(dw, chan->dir, chan->id, llp.msb,
+			  upper_32_bits(chunk->ll_region.paddr));
 		#else /* CONFIG_64BIT */
-			SET_CH_32(dw, chan->dir, chan->id, llp.lsb,
-				  lower_32_bits(chunk->ll_region.paddr));
-			SET_CH_32(dw, chan->dir, chan->id, llp.msb,
-				  upper_32_bits(chunk->ll_region.paddr));
+		SET_CH_32(dw, chan->dir, chan->id, llp.lsb,
+			  lower_32_bits(chunk->ll_region.paddr));
+		SET_CH_32(dw, chan->dir, chan->id, llp.msb,
+			  upper_32_bits(chunk->ll_region.paddr));
 		#endif /* CONFIG_64BIT */
 	}
 	/* Doorbell */

--- a/akida-pcie-core.c
+++ b/akida-pcie-core.c
@@ -396,7 +396,7 @@ static const struct vm_operations_struct akida_vm_ops = {
 #endif
 };
 
-static int akida_mmap(struct file *file, struct vm_area_struct *vma)
+static int akida_1000_mmap(struct file *file, struct vm_area_struct *vma)
 {
 	struct akida_dev *akida =
 		container_of(file->private_data, struct akida_dev, miscdev);
@@ -418,12 +418,12 @@ static int akida_mmap(struct file *file, struct vm_area_struct *vma)
 				  vma->vm_page_prot);
 }
 
-static const struct file_operations akida_fops = {
+static const struct file_operations akida_1000_fops = {
 	.owner = THIS_MODULE,
 	.write = akida_write,
 	.read = akida_read,
 	.llseek = no_seek_end_llseek,
-	.mmap = akida_mmap,
+	.mmap = akida_1000_mmap,
 };
 
 struct akida_iatu_conf {
@@ -431,7 +431,7 @@ struct akida_iatu_conf {
 	u32 val;
 };
 
-static const struct akida_iatu_conf akida_iatu_conf_table[] = {
+static const struct akida_iatu_conf akida_1000_iatu_conf_table[] = {
 	/* Akida BAR
 	 * Region 0 inbound (31:dir N-0:Region Index)
 	 * Function 0 Mem   (22-20:function)
@@ -469,9 +469,9 @@ static const struct akida_iatu_conf akida_iatu_conf_table[] = {
 	{0}
 };
 
-static int akida_setup_iatu(struct pci_dev *pdev)
+static int akida_1000_setup_iatu(struct pci_dev *pdev)
 {
-	const struct akida_iatu_conf *conf = akida_iatu_conf_table;
+	const struct akida_iatu_conf *conf = akida_1000_iatu_conf_table;
 	int ret;
 
 	while (conf->addr) {
@@ -612,7 +612,7 @@ static const struct dw_edma_core_ops akida_dw_edma_core_ops = {
 	.irq_vector = akida_dw_edma_pcie_irq_vector,
 };
 
-static int akida_probe(struct pci_dev *pdev, const struct pci_device_id *id)
+static int akida_1000_probe(struct pci_dev *pdev, const struct pci_device_id *id)
 {
 	struct akida_dev *akida;
 	int ret, nr_irqs;
@@ -627,7 +627,7 @@ static int akida_probe(struct pci_dev *pdev, const struct pci_device_id *id)
 	pci_disable_link_state(pdev, PCIE_LINK_STATE_L0S | PCIE_LINK_STATE_L1);
 
 	/* Setup iATU */
-	ret = akida_setup_iatu(pdev);
+	ret = akida_1000_setup_iatu(pdev);
 	if (ret) {
 		pci_err(pdev, "seting up iATU failed (%d)\n", ret);
 		return ret;
@@ -864,7 +864,7 @@ static int akida_probe(struct pci_dev *pdev, const struct pci_device_id *id)
 	akida->miscdev.minor = MISC_DYNAMIC_MINOR;
 	akida->miscdev.name = devm_kasprintf(&pdev->dev, GFP_KERNEL,
 					     "akida%d", akida->devno);
-	akida->miscdev.fops = &akida_fops;
+	akida->miscdev.fops = &akida_1000_fops;
 	akida->miscdev.parent = &pdev->dev;
 
 	pci_set_drvdata(pdev, akida);
@@ -919,12 +919,12 @@ static void akida_remove(struct pci_dev *pdev)
 #define PCI_VENDOR_ID_BRAINCHIP 0x1e7c
 #endif
 
-#ifndef PCI_DEVICE_ID_BRAINCHIP_AKIDA
-#define PCI_DEVICE_ID_BRAINCHIP_AKIDA 0xbca1
+#ifndef PCI_DEVICE_ID_BRAINCHIP_AKIDA_1000
+#define PCI_DEVICE_ID_BRAINCHIP_AKIDA_1000 0xbca1
 #endif
 
 static const struct pci_device_id akida_pci_ids[] = {
-	{ PCI_DEVICE(PCI_VENDOR_ID_BRAINCHIP, PCI_DEVICE_ID_BRAINCHIP_AKIDA) },
+	{ PCI_DEVICE(PCI_VENDOR_ID_BRAINCHIP, PCI_DEVICE_ID_BRAINCHIP_AKIDA_1000) },
 	{ 0 }
 };
 
@@ -933,7 +933,7 @@ MODULE_DEVICE_TABLE(pci, akida_pci_ids);
 static struct pci_driver akida_driver = {
 	.name		= "akida-pcie",
 	.id_table	= akida_pci_ids,
-	.probe		= akida_probe,
+	.probe		= akida_1000_probe,
 	.remove		= akida_remove,
 };
 

--- a/akida-pcie-core.c
+++ b/akida-pcie-core.c
@@ -653,9 +653,17 @@ static int akida_probe(struct pci_dev *pdev, const struct pci_device_id *id)
 	}
 
 	/* DMA configuration */
+#if LINUX_VERSION_CODE <= KERNEL_VERSION(5, 17, 0)
 	ret = pci_set_dma_mask(pdev, DMA_BIT_MASK(64));
+#else
+	ret = dma_set_mask(&pdev->dev, DMA_BIT_MASK(64));
+#endif
 	if (!ret) {
+#if LINUX_VERSION_CODE <= KERNEL_VERSION(5, 17, 0)
 		ret = pci_set_consistent_dma_mask(pdev, DMA_BIT_MASK(64));
+#else
+		ret = dma_set_coherent_mask(&pdev->dev, DMA_BIT_MASK(64));
+#endif
 		if (ret) {
 			pci_err(pdev, "consistent DMA mask 64 set failed (%d)\n", ret);
 			return ret;
@@ -663,13 +671,21 @@ static int akida_probe(struct pci_dev *pdev, const struct pci_device_id *id)
 	} else {
 		pci_warn(pdev, "DMA mask 64 set failed\n");
 
+#if LINUX_VERSION_CODE <= KERNEL_VERSION(5, 17, 0)
 		ret = pci_set_dma_mask(pdev, DMA_BIT_MASK(32));
+#else
+		ret = dma_set_mask(&pdev->dev, DMA_BIT_MASK(32));
+#endif
 		if (ret) {
 			pci_err(pdev, "DMA mask 32 set failed (%d)\n", ret);
 			return ret;
 		}
 
+#if LINUX_VERSION_CODE <= KERNEL_VERSION(5, 17, 0)
 		ret = pci_set_consistent_dma_mask(pdev, DMA_BIT_MASK(32));
+#else
+		ret = dma_set_coherent_mask(&pdev->dev, DMA_BIT_MASK(32));
+#endif
 		if (ret) {
 			pci_err(pdev, "consistent DMA mask 32 set failed (%d)\n", ret);
 			return ret;


### PR DESCRIPTION
These changes add support to Akida 1500 board.
Support only mmap operation for now.
The two BAR memories accessible are 0xFCC0_0000 to 0xFCFF_FFFF for BAR 2 and 0x2000_0000 to 0x203F_FFFF for BAR 4.

The mmap test has been updated accordingly and is still compatible with old Akida 1000 board.
Here is the test example:
  $ ./mmap_access /dev/akd1500_0 0xfcc00054 32
  0x10010114

Perform 32bit write, 0xcafedeca value at  0x20000020  (Memory):
  $ ./mmap_access /dev/akd1500_0 0x20000020 32 0xcafedeca
  $ ./mmap_access /dev/akd1500_0 0x20000020 32
  0xcafedeca