### PR TITLE
Host DDR accesses

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ ifneq ($(KERNELRELEASE),)
 # copied in kernel/x.y/ subdirectory depending on kernel API changes.
 # These files are drivers/dma/dmaengine.h and drivers/dma/virt-dma.h
 AKIDA_KERNEL_VERSION_RANK := $(shell \
-	printf "$(VERSION).$(PATCHLEVEL)\n5.4\n5.6\n5.7\n5.9\n5.16\n6.4\n" | \
+	printf "$(VERSION).$(PATCHLEVEL)\n5.4\n5.6\n5.7\n5.9\n5.16\n6.7\n" | \
 	sort -V )
 
 ifneq ($(word 1,$(AKIDA_KERNEL_VERSION_RANK)), 5.4)
@@ -38,7 +38,7 @@ akida-pcie-y += akida-dw-edma/dw-edma-v0-core.o
 akida-pcie-y += akida-dw-edma/dw-edma-v0-debugfs.o
 akida-pcie-y += akida-dw-edma/dw-hdma-v0-core.o
 akida-pcie-y += akida-dw-edma/dw-hdma-v0-debugfs.o
-else ifneq ($(word 6,$(AKIDA_KERNEL_VERSION_RANK)), 6.4)
+else ifneq ($(word 6,$(AKIDA_KERNEL_VERSION_RANK)), 6.7)
 ccflags-y += -I$(src)/kernel/5.16/drivers/dma
 akida-pcie-y += akida-dw-edma/dw-edma-core.o
 akida-pcie-y += akida-dw-edma/dw-edma-v0-core.o

--- a/akida-pcie-core.c
+++ b/akida-pcie-core.c
@@ -446,11 +446,11 @@ static int akida_1500_mmap(struct file *file, struct vm_area_struct *vma)
 	size[1] = ((pci_resource_len(akida->pdev, BAR_4) - 1) >> PAGE_SHIFT) + 1;
 
 	if (start[0] <= vma->vm_pgoff &&
-	    (vma->vm_pgoff + vma_pages(vma)) < (start[0] + size[0])) {
+	    (vma->vm_pgoff + vma_pages(vma)) <= (start[0] + size[0])) {
 		bar = BAR_2;
 		vma->vm_pgoff -= start[0];
 	} else if (start[1] <= vma->vm_pgoff &&
-		   (vma->vm_pgoff + vma_pages(vma)) < (start[1] + size[1])) {
+		   (vma->vm_pgoff + vma_pages(vma)) <= (start[1] + size[1])) {
 		bar = BAR_4;
 		vma->vm_pgoff -= start[1];
 	} else

--- a/akida-pcie-core.c
+++ b/akida-pcie-core.c
@@ -805,20 +805,6 @@ static int akida_probe(struct pci_dev *pdev, const struct pci_device_id *id)
 
 	pci_set_master(pdev);
 
-	/* Setup iATU */
-	ret = ops.setup_iatu(akida);
-	if (ret) {
-		pci_err(pdev, "seting up iATU failed (%d)\n", ret);
-		return ret;
-	}
-
-	/* Mapping PCI BAR regions */
-	ret = ops.setup_iomap(pdev);
-	if (ret) {
-		pci_err(pdev, "BAR I/O remapping failed (%d)\n", ret);
-		return ret;
-	}
-
 	/* DMA configuration */
 #if LINUX_VERSION_CODE <= KERNEL_VERSION(5, 17, 0)
 	ret = pci_set_dma_mask(pdev, DMA_BIT_MASK(64));
@@ -857,6 +843,20 @@ static int akida_probe(struct pci_dev *pdev, const struct pci_device_id *id)
 			pci_err(pdev, "consistent DMA mask 32 set failed (%d)\n", ret);
 			return ret;
 		}
+	}
+
+	/* Setup iATU */
+	ret = ops.setup_iatu(akida);
+	if (ret) {
+		pci_err(pdev, "seting up iATU failed (%d)\n", ret);
+		return ret;
+	}
+
+	/* Mapping PCI BAR regions */
+	ret = ops.setup_iomap(pdev);
+	if (ret) {
+		pci_err(pdev, "BAR I/O remapping failed (%d)\n", ret);
+		return ret;
 	}
 
 	/* IRQs allocation */

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,5 +1,5 @@
 CC ?= gcc
-CFLAGS ?= -Wall -Wextra -Werror -Wno-unused-parameter -pthread
+CFLAGS ?= -O3 -Wall -Wextra -Werror -Wno-unused-parameter -pthread
 LDFLAGS ?= -pthread
 
 ifeq ($(V),)

--- a/test/Makefile
+++ b/test/Makefile
@@ -8,7 +8,7 @@ else
 Q :=
 endif
 
-all: test mmap_access
+all: test test_host_ddr mmap_access
 .PHONY: all
 
 %.o: %.c Makefile
@@ -19,6 +19,10 @@ test: test.o
 	@printf "  LNK  $@\n"
 	$(Q)$(CC) $(LDFLAGS) $(LDLIBS) -o $@ $^
 
+test_host_ddr: test_host_ddr.o
+	@printf "  LNK  $@\n"
+	$(Q)$(CC) $(LDFLAGS) $(LDLIBS) -o $@ $^
+
 mmap_access: mmap_access.o
 	@printf "  LNK  $@\n"
 	$(Q)$(CC) $(LDFLAGS) $(LDLIBS) -o $@ $^
@@ -26,5 +30,6 @@ mmap_access: mmap_access.o
 clean:
 	@rm -f *.o
 	@rm -f test
+	@rm -f test_host_ddr
 	@rm -f mmap_access
 .PHONY: all

--- a/test/akd500_akdma_rc.sh
+++ b/test/akd500_akdma_rc.sh
@@ -1,0 +1,85 @@
+#! /bin/sh
+
+AKIDA_DEV=/dev/akd1500_0
+
+MYDIR=`dirname $(realpath $0)`
+
+akd_write32() {
+	echo "Write32 @$1 $2"
+	$MYDIR/mmap_access $AKIDA_DEV $1 32 $2
+}
+
+akd_read32() {
+	val=$($MYDIR/mmap_access $AKIDA_DEV $1 32)
+	echo "Read32 @$1 $val"
+}
+
+
+## Test EP to RC using Akida DMA
+
+# AKD1500 DMA Reset, issued from RC
+akd_read32 0xfcc20000
+akd_read32 0xfcc20004
+akd_read32 0xfcc20008
+akd_read32 0xfcc2000c
+akd_write32 0xfcc20000 0x83000200
+# Add Delay for rest to finish
+akd_read32 0xfcc20000
+akd_read32 0xfcc20004
+akd_read32 0xfcc20008
+akd_read32 0xfcc2000c
+# AKD1500 DMA Setup. Enable DMA and choose mode of operation
+akd_write32 0xfcc20000 0x83000502
+# DMA Descriptor Base Address. This should point to the starting location of the DMA Descriptors
+akd_write32 0xfcc20008 0xc0001000
+# DMA Loopback. DMA Ibound Channel is Looped back to Outbound Channel before packet formating. This behaves like a pure data transfer DMA.
+# In Loopback mode Inbound (Source) and Outbound (Destination) Data should match in this mode 
+akd_write32 0xfcc200b0 0x00000001
+
+## DMA Descriptor in RC Memory Space. Read payload from RC address 0x10002000 and write output at RC address 0x10003000
+## Note that the payload inbound and outbound addresses in Word#2 & 4 of descriptor (at 0x10001004 and 0x1000100c) is relative to EP address map 
+## If more than one descriptors needed, the next one starts at offset 0x40 from Descriptor Base adddress, and so on...
+# Word#1 is for internal use. Keep 0
+akd_write32 0xc0001000 0
+# Word#2 is the payload's source address. Since this will be initated from the AKD1500 DMA, it should be the translated address to EP space 
+akd_write32 0xc0001004 0xc0002000
+# Specifies the number of 32b data to transfer
+akd_write32 0xc0001008 4
+# Specifies the Destination address. Since this will be initated from the AKD1500 DMA, it should be the translated address to EP space 
+akd_write32 0xc000100c 0xc0003000
+
+# Source Data in RC memory. Starting Address is the one specified in word#2 of DMA descriptor (at 0x10001004)
+akd_write32 0xc0002000 0xbabeface
+akd_write32 0xc0002004 0xdeadc0de
+akd_write32 0xc0002008 0xabcdef01
+akd_write32 0xc000200c 0x12345678
+
+#Clear OB memory space. Initial value for reference when comapring source and destination data.
+akd_write32 0xc0003000 0
+akd_write32 0xc0003020 0
+akd_write32 0xc0003024 0
+akd_write32 0xc0003028 0
+akd_write32 0xc000302c 0
+#Read RC memory
+akd_read32 0xc0003000
+akd_read32 0xc0003020
+akd_read32 0xc0003024
+akd_read32 0xc0003028
+akd_read32 0xc000302c
+
+
+# Advance EP AK DMA Descriptor. Upper 16bits specify the descriptor to execute, 0 being descriptor #0 at base address, 1 begin descriptor #1 at base address + 0x40, ....
+# In this instance, only one descriptor is executed (descriptor #0)
+akd_write32 0xfcc20004 00000000
+
+#Check EP DMA Status. A value 0x3 in lower bits indicate that the transfer is complete
+akd_read32 0xfcc20024
+akd_read32 0xfcc20028
+
+#Read RC memory at. Source data should overwrite the initial 0 data 
+akd_read32 0xc0003000
+akd_read32 0xc0003020
+akd_read32 0xc0003024
+akd_read32 0xc0003028
+akd_read32 0xc000302c
+

--- a/test/spdk/Readme.txt
+++ b/test/spdk/Readme.txt
@@ -1,0 +1,6 @@
+The barrier.h file present in this directory has been extracted from the SPDK
+project https://github.com/spdk/spdk, branch master, commit 9bec3f5.
+The original file in the spdk project is include/spdk/barrier.h.
+
+These files has been modified to simply remove its '#include "spdk/stdinc.h"
+line. Its original BSD-3-Clause license is kept unchanged.

--- a/test/spdk/barrier.h
+++ b/test/spdk/barrier.h
@@ -1,0 +1,113 @@
+/*   SPDX-License-Identifier: BSD-3-Clause
+ *   Copyright (C) 2015 Intel Corporation.
+ *   Copyright (c) 2017, IBM Corporation.
+ *   All rights reserved.
+ */
+
+/** \file
+ * Memory barriers
+ */
+
+#ifndef SPDK_BARRIER_H
+#define SPDK_BARRIER_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Compiler memory barrier */
+#define spdk_compiler_barrier() __asm volatile("" ::: "memory")
+
+/** Read memory barrier */
+#define spdk_rmb()	_spdk_rmb()
+
+/** Write memory barrier */
+#define spdk_wmb()	_spdk_wmb()
+
+/** Full read/write memory barrier */
+#define spdk_mb()	_spdk_mb()
+
+/** SMP read memory barrier. */
+#define spdk_smp_rmb()	_spdk_smp_rmb()
+
+/** SMP write memory barrier. */
+#define spdk_smp_wmb()	_spdk_smp_wmb()
+
+/** SMP read/write memory barrier. */
+#define spdk_smp_mb()	_spdk_smp_mb()
+
+/** Invalidate data cache, input is data pointer */
+#define spdk_ivdt_dcache(pdata)	_spdk_ivdt_dcache(pdata)
+
+#ifdef __PPC64__
+
+#define _spdk_rmb()	__asm volatile("sync" ::: "memory")
+#define _spdk_wmb()	__asm volatile("sync" ::: "memory")
+#define _spdk_mb()	__asm volatile("sync" ::: "memory")
+#define _spdk_smp_rmb()	__asm volatile("lwsync" ::: "memory")
+#define _spdk_smp_wmb()	__asm volatile("lwsync" ::: "memory")
+#define _spdk_smp_mb()	spdk_mb()
+#define _spdk_ivdt_dcache(pdata)
+
+#elif defined(__aarch64__)
+
+#define _spdk_rmb()	__asm volatile("dsb ld" ::: "memory")
+#define _spdk_wmb()	__asm volatile("dsb st" ::: "memory")
+#define _spdk_mb()	__asm volatile("dsb sy" ::: "memory")
+#define _spdk_smp_rmb()	__asm volatile("dmb ishld" ::: "memory")
+#define _spdk_smp_wmb()	__asm volatile("dmb ishst" ::: "memory")
+#define _spdk_smp_mb()	__asm volatile("dmb ish" ::: "memory")
+#define _spdk_ivdt_dcache(pdata)	asm volatile("dc civac, %0" : : "r"(pdata) : "memory");
+
+#elif defined(__i386__) || defined(__x86_64__)
+
+#define _spdk_rmb()	__asm volatile("lfence" ::: "memory")
+#define _spdk_wmb()	__asm volatile("sfence" ::: "memory")
+#define _spdk_mb()	__asm volatile("mfence" ::: "memory")
+#define _spdk_smp_rmb()	spdk_compiler_barrier()
+#define _spdk_smp_wmb()	spdk_compiler_barrier()
+#if defined(__x86_64__)
+#define _spdk_smp_mb()	__asm volatile("lock addl $0, -128(%%rsp); " ::: "memory");
+#elif defined(__i386__)
+#define _spdk_smp_mb()	__asm volatile("lock addl $0, -128(%%esp); " ::: "memory");
+#endif
+#define _spdk_ivdt_dcache(pdata)
+
+#elif defined(__riscv)
+
+#define _spdk_rmb()	__asm__ __volatile__("fence ir, ir" ::: "memory")
+#define _spdk_wmb()	__asm__ __volatile__("fence ow, ow" ::: "memory")
+#define _spdk_mb()	__asm__ __volatile__("fence iorw, iorw" ::: "memory")
+#define _spdk_smp_rmb()	__asm__ __volatile__("fence r, r" ::: "memory")
+#define _spdk_smp_wmb()	__asm__ __volatile__("fence w, w" ::: "memory")
+#define _spdk_smp_mb()	__asm__ __volatile__("fence rw, rw" ::: "memory")
+#define _spdk_ivdt_dcache(pdata)
+
+#elif defined(__loongarch__)
+
+#define _spdk_rmb()	__asm volatile("dbar 0" ::: "memory")
+#define _spdk_wmb()	__asm volatile("dbar 0" ::: "memory")
+#define _spdk_mb()	__asm volatile("dbar 0" ::: "memory")
+#define _spdk_smp_rmb()	__asm volatile("dbar 0" ::: "memory")
+#define _spdk_smp_wmb()	__asm volatile("dbar 0" ::: "memory")
+#define _spdk_smp_mb()	__asm volatile("dbar 0" ::: "memory")
+#define _spdk_ivdt_dcache(pdata)
+
+#else
+
+#define _spdk_rmb()
+#define _spdk_wmb()
+#define _spdk_mb()
+#define _spdk_smp_rmb()
+#define _spdk_smp_wmb()
+#define _spdk_smp_mb()
+#define _spdk_ivdt_dcache(pdata)
+#error Unknown architecture
+
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/test/spdk/bsd-3-clause.txt
+++ b/test/spdk/bsd-3-clause.txt
@@ -1,0 +1,9 @@
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/test/test_host_ddr.c
+++ b/test/test_host_ddr.c
@@ -1,0 +1,486 @@
+#include <errno.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "spdk/barrier.h"
+
+#define barrier_rmb	spdk_rmb
+#define barrier_wmb	spdk_wmb
+#define barrier_mb	spdk_mb
+
+struct mmap_area {
+	void *virt_addr;
+	uint32_t phy_addr;
+	size_t size;
+};
+
+static int mmap_area_init(struct mmap_area *mmap_area, const char *devpath, uint32_t phy_addr, size_t size)
+{
+	int fd;
+	int err;
+
+	memset(mmap_area, 0, sizeof(*mmap_area));
+
+	fd = open(devpath, O_RDWR);
+	if (fd < 0) {
+		err = errno;
+		fprintf(stderr,"open(%s) failed (%d-%s)\n",
+			devpath, err, strerror(err));
+		return err;
+	}
+
+	/* mmap the area */
+	mmap_area->virt_addr = mmap(NULL, size, PROT_READ | PROT_WRITE,
+			MAP_SHARED, fd, phy_addr);
+
+	close(fd);
+	if (mmap_area->virt_addr == MAP_FAILED) {
+		err = errno;
+		fprintf(stderr,"mmap(%s, %zu, 0x%"PRIx32") failed (%d-%s)\n",
+			devpath, size, phy_addr, err, strerror(err));
+		return err;
+	}
+
+	mmap_area->phy_addr = phy_addr;
+	mmap_area->size = size;
+
+	return 0;
+}
+
+static void mmap_area_exit(struct mmap_area *mmap_area)
+{
+	/* unmap the area */
+	munmap(mmap_area->virt_addr, mmap_area->size);
+}
+
+static uint32_t mmap_area_virt2phy(struct mmap_area *mmap_area, void *virt_addr)
+{
+	ptrdiff_t offset;
+
+	offset = virt_addr - mmap_area->virt_addr;
+
+	return mmap_area->phy_addr + offset;
+}
+
+static void io_write32(void *addr, uint32_t val)
+{
+	barrier_wmb();
+	*((volatile uint32_t *)addr) = val;
+}
+
+static uint32_t io_read32(void *addr)
+{
+	uint32_t val;
+
+	val = *((volatile uint32_t *)addr);
+	barrier_rmb();
+
+	return val;
+}
+
+static void timestamp_get(struct timespec *t)
+{
+	clock_gettime(CLOCK_MONOTONIC_RAW, t);
+}
+
+static void timestamp_from_usec(struct timespec *t, useconds_t usec)
+{
+	if (usec < 1000000) {
+		t->tv_sec = 0;
+		t->tv_nsec = usec;
+		t->tv_nsec *= 1000;
+		return;
+	}
+
+	t->tv_sec = usec / 1000000;
+	t->tv_nsec = usec % 1000000;
+	t->tv_nsec *= 1000;
+}
+
+static void timestamp_delta(struct timespec *tdelta, const struct timespec *tstart,
+			    const struct timespec *tend)
+{
+	tdelta->tv_sec = tend->tv_sec - tstart->tv_sec;
+	tdelta->tv_nsec = tend->tv_nsec - tstart->tv_nsec;
+	if (tdelta->tv_nsec < 0) {
+		tdelta->tv_sec--;
+		tdelta->tv_nsec += 1000000000;
+	}
+}
+
+static int timestamp_cmp(const struct timespec *t1, const struct timespec *t2)
+{
+	/*
+	 * Returns:
+	 *  - negative if t1 < t2
+	 *  - 0 if t1 == t2
+	 *  - positive if t1 > t2
+	 */
+	if (t1->tv_sec == t2->tv_sec) {
+		if (t1->tv_nsec > t2->tv_nsec)
+			return 1;
+		if (t1->tv_nsec < t2->tv_nsec)
+			return -1;
+		return 0;
+	}
+	if (t1->tv_sec < t2->tv_sec)
+		return -1;
+	return 1;
+}
+
+static int timestamp_is_timeout(const struct timespec *tstart, const struct timespec *timeout)
+{
+	struct timespec delta;
+
+	timestamp_get(&delta);
+	timestamp_delta(&delta, tstart, &delta);
+	return timestamp_cmp(&delta, timeout) > 0;
+}
+
+static void timestamp_print(const char *txt_prefix, const struct timespec *t)
+{
+	printf("%s%ld.%06lds\n", txt_prefix, t->tv_sec, t->tv_nsec/1000);
+}
+
+static void timestamp_print_delta(const char *txt_prefix, const struct timespec *tstart,
+				  const struct timespec *tend)
+{
+	struct timespec tdelta;
+
+	timestamp_delta(&tdelta, tstart, tend);
+	timestamp_print(txt_prefix, &tdelta);
+}
+
+
+struct dma_descriptor {
+	uint32_t ctrl;
+	uint32_t src;
+	uint32_t size;
+	uint32_t dst;
+} __attribute__((packed));
+
+static void dma_reset(struct mmap_area *dma)
+{
+	void *dma_base = dma->virt_addr;
+
+	/* AKD1500 DMA Reset */
+	io_write32(dma_base, 0x83000200);
+}
+
+static void dma_init(struct mmap_area *dma, uint32_t first_desc_addr)
+{
+	void *dma_base = dma->virt_addr;
+
+	/* Set up the DMA controller: Enable DMA and loopback mode */
+	io_write32(dma_base, 0x83000502);
+	io_write32(dma_base + 0x0b0, 0x00000001);
+
+	/* Set the starting DMA descriptor */
+	io_write32(dma_base + 0x008, first_desc_addr);
+}
+
+static void dma_start(struct mmap_area *dma, uint32_t desc_number)
+{
+	void *dma_base = dma->virt_addr;
+
+	/*
+	 * Be sure that data and descriptor accesses done
+	 * barrier_wmb();
+	 * This will be done by io_write32() here after.
+	 * -> Not needed here
+	 */
+
+	/* Start the DMA with descriptor #0 */
+	io_write32(dma_base + 0x004, 0x00000000);
+}
+
+static int dma_wait(struct mmap_area *dma, useconds_t usec_timeout)
+{
+	void *dma_base = dma->virt_addr;
+	struct timespec tstart, timeout;
+
+	timestamp_from_usec(&timeout, usec_timeout);
+	timestamp_get(&tstart);
+
+	/* Wait for the end of DMA */
+	while ((io_read32(dma_base + 0x028) & 0x00000003) != 0x00000003) {
+		if (timestamp_is_timeout(&tstart, &timeout)) {
+			fprintf(stderr,"DMA transfer timeout\n");
+			return ETIMEDOUT;
+		}
+	}
+
+	/*
+	 * Be sure that all memory read will be done after
+	 * barrier_rmb();
+	 * This is already done by io_read32()
+	 * -> Not needed here
+	 */
+
+	return 0;
+}
+
+static const uint32_t pattern[] = {
+	0xCAFEDECA,
+	0xDEADBEAF,
+	0x12345678,
+	0x55AA00FF,
+};
+
+static int test_host_ddr_simple(struct mmap_area *ddr, struct mmap_area *dma, int is_verbose, unsigned long param)
+{
+	struct timespec tstart, tend;
+	struct dma_descriptor *desc;
+	uint32_t *data_src;
+	uint32_t *data_dst;
+	uint32_t tmp;
+	int count;
+	int err;
+
+	/* AKD1500 DMA Reset, issued from RC */
+	dma_reset(dma);
+
+	desc     = ddr->virt_addr + 0x1000;
+	data_src = ddr->virt_addr + 0x2000;
+	data_dst = ddr->virt_addr + 0x3000;
+
+	if (is_verbose)
+		printf("   xfer size: %zu bytes\n", 4 * sizeof(uint32_t));
+
+	timestamp_get(&tstart);
+
+	/* Initialize the source data */
+	memcpy(data_src, pattern, 4 * sizeof(uint32_t));
+
+	timestamp_get(&tend);
+	if (is_verbose)
+		timestamp_print_delta("   prepare src data duration: ", &tstart, &tend);
+
+	/* Zeroize the destination data */
+	memset(data_dst,0, (8 + 4) * sizeof(uint32_t));
+
+	/* Set the DMA descriptor */
+	desc->ctrl = 0;
+	desc->src  = mmap_area_virt2phy(ddr, data_src);
+	desc->size = 4;
+	desc->dst  = mmap_area_virt2phy(ddr, data_dst);
+
+	/* Initialize the DMA controller */
+	dma_init(dma, mmap_area_virt2phy(ddr, desc));
+
+	timestamp_get(&tstart);
+
+	/* Start the DMA with descriptor #0 */
+	dma_start(dma, 0);
+
+	/* Wait for the end of DMA */
+	err = dma_wait(dma, 1*1000*1000);
+	if (err) {
+		fprintf(stderr,"dma_wait() failed (%d-%s)\n",
+			err, strerror(err));
+		return err;
+	}
+
+	timestamp_get(&tend);
+	if (is_verbose)
+		timestamp_print_delta("   DMA duration: ", &tstart, &tend);
+
+	timestamp_get(&tstart);
+
+	/* Checked destination data */
+	for (count = 0; count < 4; count++) {
+		tmp = *(data_dst + 8 + count);
+		if (tmp != pattern[count]) {
+			fprintf(stderr,"dest[%d] = 0x%"PRIx32" != 0x%"PRIx32"\n",
+				count, tmp, pattern[count]);
+			return EILSEQ;
+		}
+	}
+
+	timestamp_get(&tend);
+	if (is_verbose)
+		timestamp_print_delta("   check dst data duration: ", &tstart, &tend);
+
+	return 0;
+}
+
+static int test_host_ddr_size(struct mmap_area *ddr, struct mmap_area *dma, int is_verbose, unsigned long param)
+{
+	struct timespec tstart, tend;
+	struct dma_descriptor *desc;
+	uint32_t *data_src;
+	uint32_t *data_dst;
+	uint32_t read, exp;
+	size_t data_size;
+	size_t count;
+	int err;
+
+	/* AKD1500 DMA Reset, issued from RC */
+	dma_reset(dma);
+
+	/* Host DDR : max 16 MB (0x01000000)
+	 * @0x00000000-0x0000001f: one DMA descriptor
+	 * @0x00000020-0x007fffff: data src size up to 0x7fffe0
+	 * @0x00800000-0x00ffffff: data dst size 0x20 + up to 0x7fffe0
+	 */
+	data_size = param;
+	if (data_size > 0x7fffe0) {
+		fprintf(stderr,"xfer size %zu (0x%zx), max supported %u (0x%x)\n",
+			data_size, data_size, 0x7fffe0, 0x7fffe0);
+		return EINVAL;
+	}
+	desc = ddr->virt_addr;
+	data_src = ddr->virt_addr + 0x00000020;
+	data_dst = ddr->virt_addr + 0x00800000;
+
+	if (is_verbose)
+		printf("   xfer size: %zu bytes\n", data_size);
+
+	timestamp_get(&tstart);
+
+	/* Initialize the source data */
+	for (count = 0; count < data_size/sizeof(uint32_t); count++)
+		*(data_src + count) = count;
+
+	timestamp_get(&tend);
+	if (is_verbose)
+		timestamp_print_delta("   prepare src data duration: ", &tstart, &tend);
+
+	/* Zeroize the destination data */
+	memset(data_dst,0, 8 * sizeof(uint32_t) + data_size);
+
+	/* Set the DMA descriptor */
+	desc->ctrl = 0;
+	desc->src  = mmap_area_virt2phy(ddr, data_src);
+	desc->size = data_size/sizeof(uint32_t);
+	desc->dst  = mmap_area_virt2phy(ddr, data_dst);
+
+	/* Initialize the DMA controller */
+	dma_init(dma, mmap_area_virt2phy(ddr, desc));
+
+	timestamp_get(&tstart);
+
+	/* Start the DMA with descriptor #0 */
+	dma_start(dma, 0);
+
+	/* Wait for the end of DMA */
+	err = dma_wait(dma, 1*1000*1000);
+	if (err) {
+		fprintf(stderr,"dma_wait() failed (%d-%s)\n",
+			err, strerror(err));
+		return err;
+	}
+
+	timestamp_get(&tend);
+	if (is_verbose)
+		timestamp_print_delta("   DMA duration: ", &tstart, &tend);
+
+	timestamp_get(&tstart);
+
+	/* Checked destination data */
+	for (count = 0; count < data_size / sizeof(uint32_t); count++) {
+		read = *(data_dst + 8 + count);
+		exp = *(data_src + count);
+		if (read != exp) {
+			fprintf(stderr,"dest[%zu] = 0x%"PRIx32" != 0x%"PRIx32"\n",
+				count, read, exp);
+			return EILSEQ;
+		}
+	}
+
+	timestamp_get(&tend);
+	if (is_verbose)
+		timestamp_print_delta("   check dst data duration: ", &tstart, &tend);
+
+	return 0;
+}
+
+static int do_tests(struct mmap_area *ddr, struct mmap_area *dma, int is_verbose)
+{
+	const struct test_def {
+		const char *name;
+		int (*tst_fct)(struct mmap_area *ddr, struct mmap_area *dma,
+			       int is_verbose, unsigned long param);
+		unsigned long param;
+	} tab_test[] = {
+		{ "test_host_ddr simple", test_host_ddr_simple, 0 },
+		{ "test_host_ddr   32", test_host_ddr_size, 32 },
+		{ "test_host_ddr  256", test_host_ddr_size, 256 },
+		{ "test_host_ddr 1234", test_host_ddr_size, 1234 },
+		{ "test_host_ddr 4096", test_host_ddr_size, 4096 },
+		{ "test_host_ddr 8000", test_host_ddr_size, 8000 },
+		{ "test_host_ddr  1MB", test_host_ddr_size, 1*1024*1024 },
+		{ "test_host_ddr  2MB", test_host_ddr_size, 2*1024*1024 },
+		{ "test_host_ddr  4MB", test_host_ddr_size, 4*1024*1024 },
+		{ "test_host_ddr  max", test_host_ddr_size, 0x7fffe0 },
+		{ 0}
+	}, *test;
+	int err;
+	int failed;
+
+	failed = 0;
+	test = tab_test;
+	do {
+		printf("-- %s\n", test->name);
+		err = test->tst_fct(ddr, dma, is_verbose, test->param);
+		printf("-- %s %s\n", test->name, err ? "FAILED" : "ok");
+		if (err)
+			failed++;
+	} while ((++test)->name);
+
+	return failed;
+}
+
+static void usage(const char *prog_name)
+{
+	fprintf(stderr, "%s dev\n", prog_name);
+	fprintf(stderr, "   dev     Device to use for instance /dev/akd1500_0\n");
+}
+
+int main(int argc, char* argv[])
+{
+	const char *devpath;
+	struct mmap_area dma;
+	struct mmap_area ddr;
+	int failed;
+	int err;
+
+	if ((argc < 2) || (argc > 2)) {
+		usage(argv[0]);
+		return 1;
+	}
+
+	devpath = argv[1];
+
+	/* mmap the area related to the Akida DMA controller */
+	err = mmap_area_init(&dma, devpath, 0xfcc20000, 4096);
+	if (err) {
+		fprintf(stderr,"mmap_area_init(%s, 0xfcc20000, 4096) failed (%d-%s)\n",
+			devpath, err, strerror(err));
+		return 1;
+	}
+
+	/* mmap the area related to the host DDR area */
+	err = mmap_area_init(&ddr, devpath, 0xc0000000, 16*1024*1024);
+	if (err) {
+		fprintf(stderr,"mmap_area_init(%s, 0xc0000000, 8*1024*1024) failed (%d-%s)\n",
+			devpath, err, strerror(err));
+		mmap_area_exit(&dma);
+		return 1;
+	}
+
+	/* Do the tests */
+	failed = do_tests(&ddr, &dma, 1);
+
+	mmap_area_exit(&ddr);
+	mmap_area_exit(&dma);
+	return failed ? 1 : 0;
+}


### PR DESCRIPTION
This code adds support to the host DDR accesses:
- Allocation of a 16MB chunk of memory to be used by the AKD1500
- Configure iATU to translate AKD1500 internal accesses to PCIe accesses in order for the AKD1500 to reach this chunk of memory
- Allow access to/from this memory chunk from user-space (mmap)

Also this code provides test and script programs related this feature.
