### PR TITLE
feat: add script to build kernel with CMA enable

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,36 @@ file after installation and remove `akida_pcie` line.
 
 ***After a kernel update you need to run the install script again.***
 
+## Enable CMA in the kernel
+
+Some systems, e.g.: Ubuntu on x86_64, do not come with CMA (contiguous memory
+allocation) support enabled in the kernel. This is required to use AKD1500
+devices through PCIe if you want to use larger amounts of memory to program big
+models or make full usage of the pipeline. To build the kernel packages that
+include such support you can run the dedicated script, tailored for the Ubuntu
+distribution:
+
+```
+./build_kernel_w_cma.sh
+```
+
+The script will create the packages and explain how to install and boot on the
+new kernel.
+
+If you want to go back to an old kernel that does not contain the CMA feature,
+you can grep the installed kernels that were configured in grub:
+
+```
+grep 'menuentry \|submenu ' /boot/grub/grub.cfg | cut -f2 -d "'"
+```
+
+And then modify the `/etc/default/grub` file from: `GRUB_DEFAULT=0`
+to: `GRUB_DEFAULT=2` if you want the third kernel choice in the obtained list,
+etc.
+
+Source: https://unix.stackexchange.com/questions/432393/downgrade-linux-kernel-without-grub
+
+
 ## Support
 Please visit:
 - https://doc.brainchipinc.com/ for akida documentation, examples and tutorials

--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ distribution:
 ./build_kernel_w_cma.sh
 ```
 
+> Note: this command might take long time because parallel build is not set by default. To enable that you can export this environment variable before launching the build to use a number of jobs equivalent to the number of available cores:
+>
+> `export MAKEFLAGS=$(nproc)`
+
+
 The script will create the packages and explain how to install and boot on the
 new kernel.
 

--- a/build_kernel_w_cma.sh
+++ b/build_kernel_w_cma.sh
@@ -1,12 +1,11 @@
 #!/bin/bash
 
-# This scripts builds the kernel with CMA enabled with 32MB by default, adapted for usage with AKD1500.
+# This scripts builds the kernel with CMA enabled with 64MB by default, adapted
+# for usage with AKD1500.
 #
 # Info on how to build from:
 # - https://wiki.ubuntu.com/Kernel/BuildYourOwnKernel
 # - https://askubuntu.com/questions/1435591/correct-way-to-build-kernel-with-hardware-support-fix-patches-ubuntu-22-04-lts
-
-set -e
 
 POSTFIX=-cma-akd1500
 DIRNAME=linux-kernel$POSTFIX

--- a/build_kernel_w_cma.sh
+++ b/build_kernel_w_cma.sh
@@ -49,7 +49,7 @@ chmod a+x debian/scripts/misc/*
 cp /boot/config-$(uname -r) ./.config
 
 # Modify configuration to enable CMA
-MBYTES_CMA=32
+MBYTES_CMA=64
 echo "CONFIG_CMA=y" >> ./.config
 echo "CONFIG_CMA_SIZE_MBYTES=$MBYTES_CMA" >> ./.config
 echo "CONFIG_CMA_SIZE_SEL_MBYTES=y" >> ./.config
@@ -63,7 +63,7 @@ echo "👉 Kernel will now be built, this might take a while."
 echo
 echo
 
-make -j deb-pkg LOCALVERSION=-cma-akd1500
+make deb-pkg LOCALVERSION=-cma-akd1500
 
 echo
 echo

--- a/build_kernel_w_cma.sh
+++ b/build_kernel_w_cma.sh
@@ -66,13 +66,13 @@ make deb-pkg LOCALVERSION=-cma-akd1500
 
 echo
 echo
-echo "🎉 Kernel is now built! Availables packages are in $DIRNAME:"
-echo
-ls $DIRNAME/*.deb
-echo
+echo "🎉 Kernel is now built! Availables packages are in $DIRNAME."
 echo "You can install those with these commands:"
 echo
 echo "sudo dpkg -i $DIRNAME/*.deb"
 echo "sudo update-grub"
 echo "sudo reboot"
+echo
+echo "Once rebooted, you will need to re-build the akd1500 PCIe module."
+echo "To do that, you can run './install.sh'"
 echo

--- a/build_kernel_w_cma.sh
+++ b/build_kernel_w_cma.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+# This scripts builds the kernel with CMA enabled with 32MB by default, adapted for usage with AKD1500.
+#
+# Info on how to build from:
+# - https://wiki.ubuntu.com/Kernel/BuildYourOwnKernel
+# - https://askubuntu.com/questions/1435591/correct-way-to-build-kernel-with-hardware-support-fix-patches-ubuntu-22-04-lts
+
+set -e
+
+POSTFIX=-cma-akd1500
+DIRNAME=linux-kernel$POSTFIX
+
+# Check if CMA is already enabled
+grep "CONFIG_CMA=y" /boot/config-$(uname -r)
+ret=$?
+if [ $ret -eq 0 ]; then
+    echo "CONFIG_CMA=y is present in your current kernel config, no need to"
+    echo "rebuild a new kernel."
+    exit 0
+fi
+
+mkdir -p $DIRNAME
+cd $DIRNAME
+
+sudo sed -i 's/# deb-src/deb-src/' /etc/apt/sources.list
+
+sudo apt update
+
+# Instead of:
+# sudo apt-get build-dep linux linux-image-$(uname -r)
+# This seems to work:
+sudo apt -y build-dep linux-image-generic
+
+sudo apt-get install libncurses-dev gawk flex bison openssl libssl-dev dkms libelf-dev libudev-dev libpci-dev libiberty-dev autoconf llvm
+
+sudo apt-get install git
+
+apt-get source linux-image-unsigned-$(uname -r)
+
+linux_dir=`ls -d */`
+
+cd $linux_dir
+
+chmod a+x debian/rules
+chmod a+x debian/scripts/*
+chmod a+x debian/scripts/misc/*
+
+cp /boot/config-$(uname -r) ./.config
+
+# Modify configuration to enable CMA
+MBYTES_CMA=32
+echo "CONFIG_CMA=y" >> ./.config
+echo "CONFIG_CMA_SIZE_MBYTES=$MBYTES_CMA" >> ./.config
+echo "CONFIG_CMA_SIZE_SEL_MBYTES=y" >> ./.config
+
+# update config for new kernel with default options for other settings
+make olddefconfig
+
+echo
+echo
+echo "👉 Kernel will now be built, this might take a while."
+echo
+echo
+
+make -j deb-pkg LOCALVERSION=-cma-akd1500
+
+echo
+echo
+echo "🎉 Kernel is now built! Availables packages are in $DIRNAME:"
+echo
+ls $DIRNAME/*.deb
+echo
+echo "You can install those with these commands:"
+echo
+echo "sudo dpkg -i $DIRNAME/*.deb"
+echo "sudo update-grub"
+echo "sudo reboot"
+echo


### PR DESCRIPTION
Added script that builds kernel with CMA enabled. This is required for allocating large memory area for AKD1500.