### PR TITLE
Host ddr access: Be permissive on Host DDR are size

### DIFF
--- a/akida-pcie-core.c
+++ b/akida-pcie-core.c
@@ -538,7 +538,7 @@ static const struct akida_iatu_conf akida_1000_iatu_conf_table[] = {
 
 static int akida_1500_setup_host_ddr(struct akida_dev *akida)
 {
-	akida->host_ddr.cpu_addr = dma_alloc_attrs(&akida->pdev->dev,
+	akida->host_ddr.cpu_addr = dmam_alloc_attrs(&akida->pdev->dev,
 		AKIDA_1500_HOST_DDR_SIZE, &akida->host_ddr.dma_addr,
 		GFP_KERNEL, AKIDA_1500_HOST_DDR_DMA_ATTRS);
 

--- a/akida-pcie-core.c
+++ b/akida-pcie-core.c
@@ -69,8 +69,9 @@ static DEFINE_IDA(akida_devno);
 #define AKIDA_1500_BAR2_OFFSET 0xFCC00000
 #define AKIDA_1500_BAR4_OFFSET 0x20000000
 #define AKIDA_1500_HOST_DDR_BASE 0xC0000000
-#define AKIDA_1500_HOST_DDR_SIZE SZ_4M
-#define AKIDA_1500_HOST_DDR_DMA_ATTRS DMA_ATTR_NO_KERNEL_MAPPING
+#define AKIDA_1500_HOST_DDR_SIZE_MAX  SZ_16M
+#define AKIDA_1500_HOST_DDR_SIZE_MIN  SZ_1M
+#define AKIDA_1500_HOST_DDR_DMA_ATTRS (DMA_ATTR_NO_KERNEL_MAPPING | DMA_ATTR_NO_WARN)
 
 struct akida_dma_chan {
 	struct dma_chan *chan;
@@ -95,6 +96,7 @@ struct akida_dev {
 	struct {
 		void *cpu_addr;
 		dma_addr_t dma_addr;
+		size_t size;
 	} host_ddr;
 };
 
@@ -452,7 +454,7 @@ static int akida_1500_mmap(struct file *file, struct vm_area_struct *vma)
 	start[2] = AKIDA_1500_HOST_DDR_BASE >> PAGE_SHIFT;
 	size[0] = ((pci_resource_len(akida->pdev, BAR_2) - 1) >> PAGE_SHIFT) + 1;
 	size[1] = ((pci_resource_len(akida->pdev, BAR_4) - 1) >> PAGE_SHIFT) + 1;
-	size[2] = ((AKIDA_1500_HOST_DDR_SIZE - 1) >> PAGE_SHIFT) + 1;
+	size[2] = ((akida->host_ddr.size - 1) >> PAGE_SHIFT) + 1;
 
 	if (start[0] <= vma->vm_pgoff &&
 	    (vma->vm_pgoff + vma_pages(vma)) <= (start[0] + size[0])) {
@@ -462,7 +464,7 @@ static int akida_1500_mmap(struct file *file, struct vm_area_struct *vma)
 		   (vma->vm_pgoff + vma_pages(vma)) <= (start[1] + size[1])) {
 		bar = BAR_4;
 		vma->vm_pgoff -= start[1];
-	} else if (start[2] <= vma->vm_pgoff &&
+	} else if (akida->host_ddr.size && start[2] <= vma->vm_pgoff &&
 		   (vma->vm_pgoff + vma_pages(vma)) <= (start[2] + size[2])) {
 		vma->vm_pgoff -= start[2];
 		return dma_mmap_attrs(&akida->pdev->dev, vma,
@@ -538,15 +540,28 @@ static const struct akida_iatu_conf akida_1000_iatu_conf_table[] = {
 
 static int akida_1500_setup_host_ddr(struct akida_dev *akida)
 {
-	akida->host_ddr.cpu_addr = dmam_alloc_attrs(&akida->pdev->dev,
-		AKIDA_1500_HOST_DDR_SIZE, &akida->host_ddr.dma_addr,
-		GFP_KERNEL, AKIDA_1500_HOST_DDR_DMA_ATTRS);
+	akida->host_ddr.size = AKIDA_1500_HOST_DDR_SIZE_MAX;
+	while (akida->host_ddr.size >= AKIDA_1500_HOST_DDR_SIZE_MIN) {
+		akida->host_ddr.cpu_addr = dmam_alloc_attrs(&akida->pdev->dev,
+			akida->host_ddr.size, &akida->host_ddr.dma_addr,
+			GFP_KERNEL, AKIDA_1500_HOST_DDR_DMA_ATTRS);
 
-	if (!akida->host_ddr.cpu_addr) {
-		pci_err(akida->pdev, "Failed to allocate host ddr area\n");
-		return -ENOMEM;
+		if (akida->host_ddr.cpu_addr) {
+			pci_info(akida->pdev, "Host ddr area: %zu bytes\n",
+				akida->host_ddr.size);
+			return 0;
+		}
+		pci_info(akida->pdev, "Host ddr area: Allocate %zu failed -> Try 0x%zu\n",
+				akida->host_ddr.size,
+				akida->host_ddr.size / 2);
+		akida->host_ddr.size /= 2;
 	}
 
+	pci_err(akida->pdev, "Failed to allocate host ddr area (0x%zu bytes)\n",
+		akida->host_ddr.size);
+
+	/* Disable the host ddr access feature */
+	akida->host_ddr.size = 0;
 	return 0;
 }
 
@@ -615,17 +630,19 @@ static int akida_1500_setup_iatu(struct akida_dev *akida)
 		conf++;
 	}
 
-	/* Host DDR
-	 * EP_iATU Region 0 Outbound Setting
-	 */
-	writel(0x00000000, akida->mmio_bar0 + 0x404);
-	writel(0x00000000, akida->mmio_bar0 + 0x400);
-	writel(AKIDA_1500_HOST_DDR_BASE, akida->mmio_bar0 + 0x408);
-	writel(0x00000000, akida->mmio_bar0 + 0x40c);
-	writel(AKIDA_1500_HOST_DDR_BASE + AKIDA_1500_HOST_DDR_SIZE - 1, akida->mmio_bar0 + 0x410);
-	writel(lower_32_bits(akida->host_ddr.dma_addr), akida->mmio_bar0 + 0x414);
-	writel(upper_32_bits(akida->host_ddr.dma_addr), akida->mmio_bar0 + 0x418);
-	writel(0x80000000, akida->mmio_bar0 + 0x404);
+	if (akida->host_ddr.size) {
+		/* Host DDR
+		 * EP_iATU Region 0 Outbound Setting
+		 */
+		writel(0x00000000, akida->mmio_bar0 + 0x404);
+		writel(0x00000000, akida->mmio_bar0 + 0x400);
+		writel(AKIDA_1500_HOST_DDR_BASE, akida->mmio_bar0 + 0x408);
+		writel(0x00000000, akida->mmio_bar0 + 0x40c);
+		writel(AKIDA_1500_HOST_DDR_BASE + akida->host_ddr.size - 1, akida->mmio_bar0 + 0x410);
+		writel(lower_32_bits(akida->host_ddr.dma_addr), akida->mmio_bar0 + 0x414);
+		writel(upper_32_bits(akida->host_ddr.dma_addr), akida->mmio_bar0 + 0x418);
+		writel(0x80000000, akida->mmio_bar0 + 0x404);
+	}
 
 	/* Provide 1000ms sleep for iATU's to be setup */
 	msleep(1000);

--- a/test/test_host_ddr.c
+++ b/test/test_host_ddr.c
@@ -463,15 +463,18 @@ static int do_tests(struct mmap_area *ddr, struct mmap_area *dma, struct tests_s
 		unsigned long param;
 	} tab_test[] = {
 		{ "test_host_ddr simple", test_host_ddr_simple, 0 },
-		{ "test_host_ddr   32", test_host_ddr_size, 32 },
-		{ "test_host_ddr  256", test_host_ddr_size, 256 },
-		{ "test_host_ddr 1236", test_host_ddr_size, 1236 },
-		{ "test_host_ddr 4096", test_host_ddr_size, 4096 },
-		{ "test_host_ddr 8000", test_host_ddr_size, 8000 },
-		{ "test_host_ddr  1MB", test_host_ddr_size, 1*1024*1024 },
-		{ "test_host_ddr  2MB", test_host_ddr_size, 2*1024*1024 },
-		{ "test_host_ddr  4MB", test_host_ddr_size, 4*1024*1024 },
-		{ "test_host_ddr  max", test_host_ddr_size, 0x7fffe0 },
+		{ "test_host_ddr    32", test_host_ddr_size, 32 },
+		{ "test_host_ddr   256", test_host_ddr_size, 256 },
+		{ "test_host_ddr  1236", test_host_ddr_size, 1236 },
+		{ "test_host_ddr  4096", test_host_ddr_size, 4096 },
+		{ "test_host_ddr  8000", test_host_ddr_size, 8000 },
+		{ "test_host_ddr ~1MiB", test_host_ddr_size, 1*1024*1024 - 0x20 },
+		{ "test_host_ddr  1MiB", test_host_ddr_size, 1*1024*1024 },
+		{ "test_host_ddr ~2MiB", test_host_ddr_size, 2*1024*1024 - 0x20 },
+		{ "test_host_ddr  2MiB", test_host_ddr_size, 2*1024*1024 },
+		{ "test_host_ddr ~4MiB", test_host_ddr_size, 4*1024*1024 - 0x20 },
+		{ "test_host_ddr  4MiB", test_host_ddr_size, 4*1024*1024 },
+		{ "test_host_ddr ~8MiB", test_host_ddr_size, 8*1024*1024 - 0x20 },
 		{ 0}
 	}, *test;
 	enum test_result result;

--- a/test/test_host_ddr.c
+++ b/test/test_host_ddr.c
@@ -342,18 +342,17 @@ static enum test_result test_host_ddr_size(struct mmap_area *ddr, struct mmap_ar
 	 * @0x00800000-0x00ffffff: data dst size 0x20 + up to 0x7fffe0
 	 */
 	data_size = param;
-	if (data_size > 0x7fffe0) {
-		fprintf(stderr,"xfer size %zu (0x%zx), max supported %u (0x%x)\n",
-			data_size, data_size, 0x7fffe0, 0x7fffe0);
+	if (ddr->size < (data_size + 0x20) * 2) {
+		printf("   min ddr size needed: %zu bytes\n", (data_size + 0x20) * 2);
 		return TEST_NOTDONE;
 	}
-	if (ddr->size < 0x1000000) {
-		printf("   min ddr size needed: 0x1000000 bytes\n");
+	if (data_size % 4) {
+		printf("   data size 0x%zx must be aligned on 4 bytes\n", data_size);
 		return TEST_NOTDONE;
 	}
 	desc = ddr->virt_addr;
 	data_src = ddr->virt_addr + 0x00000020;
-	data_dst = ddr->virt_addr + 0x00800000;
+	data_dst = ddr->virt_addr + 0x20 + data_size;
 
 	/* AKD1500 DMA Reset, issued from RC */
 	dma_reset(dma);
@@ -466,7 +465,7 @@ static int do_tests(struct mmap_area *ddr, struct mmap_area *dma, struct tests_s
 		{ "test_host_ddr simple", test_host_ddr_simple, 0 },
 		{ "test_host_ddr   32", test_host_ddr_size, 32 },
 		{ "test_host_ddr  256", test_host_ddr_size, 256 },
-		{ "test_host_ddr 1234", test_host_ddr_size, 1234 },
+		{ "test_host_ddr 1236", test_host_ddr_size, 1236 },
 		{ "test_host_ddr 4096", test_host_ddr_size, 4096 },
 		{ "test_host_ddr 8000", test_host_ddr_size, 8000 },
 		{ "test_host_ddr  1MB", test_host_ddr_size, 1*1024*1024 },

--- a/test/test_host_ddr.c
+++ b/test/test_host_ddr.c
@@ -251,6 +251,11 @@ static enum test_result test_host_ddr_simple(struct mmap_area *ddr, struct mmap_
 	int count;
 	int err;
 
+	if (ddr->size < 0x3000 + ((8 + 4) * sizeof(uint32_t))) {
+		printf("   min ddr size needed: %zu bytes\n",
+			0x3000 + ((8 + 4) * sizeof(uint32_t)));
+		return TEST_NOTDONE;
+	}
 
 	desc     = ddr->virt_addr + 0x1000;
 	data_src = ddr->virt_addr + 0x2000;
@@ -340,6 +345,10 @@ static enum test_result test_host_ddr_size(struct mmap_area *ddr, struct mmap_ar
 	if (data_size > 0x7fffe0) {
 		fprintf(stderr,"xfer size %zu (0x%zx), max supported %u (0x%x)\n",
 			data_size, data_size, 0x7fffe0, 0x7fffe0);
+		return TEST_NOTDONE;
+	}
+	if (ddr->size < 0x1000000) {
+		printf("   min ddr size needed: 0x1000000 bytes\n");
 		return TEST_NOTDONE;
 	}
 	desc = ddr->virt_addr;

--- a/test/test_host_ddr.c
+++ b/test/test_host_ddr.c
@@ -364,7 +364,7 @@ static enum test_result test_host_ddr_size(struct mmap_area *ddr, struct mmap_ar
 
 	/* Initialize the source data */
 	for (count = 0; count < data_size/sizeof(uint32_t); count++)
-		*(data_src + count) = count;
+		*(data_src + count) = mmap_area_virt2phy(ddr, data_dst) + count;
 
 	timestamp_get(&tend);
 	if (is_verbose)

--- a/test/test_host_ddr.c
+++ b/test/test_host_ddr.c
@@ -251,12 +251,13 @@ static enum test_result test_host_ddr_simple(struct mmap_area *ddr, struct mmap_
 	int count;
 	int err;
 
-	/* AKD1500 DMA Reset, issued from RC */
-	dma_reset(dma);
 
 	desc     = ddr->virt_addr + 0x1000;
 	data_src = ddr->virt_addr + 0x2000;
 	data_dst = ddr->virt_addr + 0x3000;
+
+	/* AKD1500 DMA Reset, issued from RC */
+	dma_reset(dma);
 
 	if (is_verbose)
 		printf("   xfer size: %zu (0x%zx) bytes\n",
@@ -330,9 +331,6 @@ static enum test_result test_host_ddr_size(struct mmap_area *ddr, struct mmap_ar
 	size_t count;
 	int err;
 
-	/* AKD1500 DMA Reset, issued from RC */
-	dma_reset(dma);
-
 	/* Host DDR : max 16 MB (0x01000000)
 	 * @0x00000000-0x0000001f: one DMA descriptor
 	 * @0x00000020-0x007fffff: data src size up to 0x7fffe0
@@ -347,6 +345,9 @@ static enum test_result test_host_ddr_size(struct mmap_area *ddr, struct mmap_ar
 	desc = ddr->virt_addr;
 	data_src = ddr->virt_addr + 0x00000020;
 	data_dst = ddr->virt_addr + 0x00800000;
+
+	/* AKD1500 DMA Reset, issued from RC */
+	dma_reset(dma);
 
 	if (is_verbose)
 		printf("   xfer size: %zu (0x%zx) bytes\n", data_size, data_size);

--- a/test/test_host_ddr.c
+++ b/test/test_host_ddr.c
@@ -259,7 +259,8 @@ static enum test_result test_host_ddr_simple(struct mmap_area *ddr, struct mmap_
 	data_dst = ddr->virt_addr + 0x3000;
 
 	if (is_verbose)
-		printf("   xfer size: %zu bytes\n", 4 * sizeof(uint32_t));
+		printf("   xfer size: %zu (0x%zx) bytes\n",
+			4 * sizeof(uint32_t), 4 * sizeof(uint32_t));
 
 	timestamp_get(&tstart);
 
@@ -348,7 +349,7 @@ static enum test_result test_host_ddr_size(struct mmap_area *ddr, struct mmap_ar
 	data_dst = ddr->virt_addr + 0x00800000;
 
 	if (is_verbose)
-		printf("   xfer size: %zu bytes\n", data_size);
+		printf("   xfer size: %zu (0x%zx) bytes\n", data_size, data_size);
 
 	timestamp_get(&tstart);
 


### PR DESCRIPTION
In order to have an akd1500 board working on low memory system and/or system without CMA
This PR update the akida driver an related test.

Patch 1: Memory leak fix.
Patch 2: Be permissive on allocation

Patch 3..9: Improve tests and prepare for runtime mmap area size detection
Patch 10: Detect mmap area size at runtime

Regards,
Hervé
