### PR TITLE
doc and build: minor adjustments

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ distribution:
 
 > Note: this command might take long time because parallel build is not set by default. To enable that you can export this environment variable before launching the build to use a number of jobs equivalent to the number of available cores:
 >
-> `export MAKEFLAGS=$(nproc)`
+> `export MAKEFLAGS="-j $(nproc)"`
 
 
 The script will create the packages and explain how to install and boot on the

--- a/build_kernel_w_cma.sh
+++ b/build_kernel_w_cma.sh
@@ -19,6 +19,8 @@ if [ $ret -eq 0 ]; then
     exit 0
 fi
 
+set -e
+
 mkdir -p $DIRNAME
 cd $DIRNAME
 
@@ -70,7 +72,6 @@ echo "🎉 Kernel is now built! Availables packages are in $DIRNAME."
 echo "You can install those with these commands:"
 echo
 echo "sudo dpkg -i $DIRNAME/*.deb"
-echo "sudo update-grub"
 echo "sudo reboot"
 echo
 echo "Once rebooted, you will need to re-build the akd1500 PCIe module."


### PR DESCRIPTION
doc: `-j` option was missing
build: exit on error, remove unecessary update-grub